### PR TITLE
feat: Add Base deployment guide and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,26 +118,25 @@ Adapters and node toml files to implement the API are available on github
 
 Truflation data is fully available on Base, with cross-chain access supported via Chainlink CCIP.
 
-**Note:** As of December 2025, the legacy Chainlink "Any API" style (with fixed job IDs) in this quickstart is primarily for testnets. On Base mainnet, Truflation recommends modern **Chainlink Data Streams** or custom streams via the Marketplace for low-latency, production use.
+**Note:** As of December 2025, the legacy Chainlink "Any API" style in this quickstart is primarily for testnets. On Base mainnet, Truflation recommends modern **Chainlink Data Streams** or custom streams via the Marketplace.
 
 For the latest configurations:
-- [Truflation Marketplace](https://marketplace.truflation.com/) – Select your data stream and Base chain to get custom oracle/job details if needed.
+- [Truflation Marketplace](https://marketplace.truflation.com/) – Select your data stream and Base chain to get custom details.
 - [Chainlink Data Streams docs](https://docs.chain.link/data-streams)
 - [Chainlink CCIP docs](https://docs.chain.link/ccip)
 
 ### Quick Steps for TruflationTester.sol on Base:
 1. Use Remix or Hardhat with Base network config (example below).
-2. When deploying the contract:
-   - Pass parameters to the **constructor** (address oracleId_, string jobId_, uint256 fee_, address token_).
+2. When deploying the contract (constructor: address oracleId_, string jobId_, uint256 fee_, address token_):
    - Get oracle address and job ID from the Truflation Marketplace (select index + Base chain).
-   - Use fee: 0.1 - 0.5 LINK (in wei, e.g., 100000000000000000 for 0.1 LINK – common for requests).
-   - LINK token address:
+   - Fee: 0.1 - 0.5 LINK (in wei, e.g., 0.1 LINK = 100000000000000000).
+   - LINK token address (official Chainlink):
      - Mainnet: 0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196
      - Testnet (Base Sepolia): 0xE4aB69C077896252FAFBD49EFD26B5D171A32410
 3. Fund your deployed contract with LINK:
-   - Testnet (Base Sepolia): Use the [Chainlink Faucet](https://faucets.chain.link/base-sepolia) (provides test LINK + ETH).
-   - Mainnet: Bridge LINK using the [official Base Bridge](https://bridge.base.org/deposit) or other trusted bridges.
-4. Call `requestYoyInflation()` on the deployed contract to fetch data.
+   - Testnet: [Chainlink Faucet for Base Sepolia](https://faucets.chain.link/base-sepolia) (provides test LINK + ETH).
+   - Mainnet: Bridge LINK using the [Base Bridge](https://bridge.base.org/deposit).
+4. Call `requestYoyInflation()` to fetch data.
 5. Example Hardhat network config (add to your `hardhat.config.js`):
    ```js
    base: {
@@ -145,3 +144,4 @@ For the latest configurations:
      accounts: [process.env.PRIVATE_KEY],
      chainId: 8453  // Use 84532 for Base Sepolia testnet
    }
+   

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ For the latest Base-compatible configurations:
 2. Open `TruflationTester.sol` and update the oracle parameters:
    - Go to the Marketplace link above, select your index and Base chain.
    - Copy the provided **oracle address** and **job ID**.
-   - Paste them into the contract (replace the placeholders in the `requestYoYInflation` function or constructor).
-3. Fund your contract with LINK on Base (use faucets for testnet like Base Sepolia, or bridges for mainnet).
+   - Paste them into the contract (typically in the constructor parameters or in the Chainlink request setup function, replacing any placeholders).
+3. Fund your contract with LINK on Base:
+   - For testnet (Base Sepolia): Use the [Chainlink Faucet](https://faucets.chain.link/base-sepolia) (provides test LINK and ETH).
+   - For mainnet: Bridge LINK from Ethereum or other chains using a trusted bridge like [Base Official Bridge](https://bridge.base.org/) or third-party options.
 4. Example Hardhat network config (add to your `hardhat.config.js`):
    ```js
    base: {

--- a/README.md
+++ b/README.md
@@ -114,3 +114,17 @@ Adapters and node toml files to implement the API are available on github
 * [Truflation discord developer chat](https://discord.com/channels/967280164071407666/968071680360587264)
 * [Network endpoints](network.md)
 * [Using solt to get a contract on etherscan](https://blog.jubb.xyz/post/solt-release/)
+## Deploying on Base (Coinbase's Layer 2)
+
+Truflation data is fully available on Base via Chainlink CCIP for cross-chain queries.
+
+### Quick Steps:
+1. Use Remix or Hardhat with Base network config.
+2. In `TruflationTester.sol`, ensure you're using the latest Chainlink oracle addresses for Base.
+3. Fund your contract with LINK on Base (get from faucets or bridges).
+4. Example network config (add to your hardhat.config.js):
+   ```js
+   base: {
+     url: "https://mainnet.base.org",
+     accounts: [process.env.PRIVATE_KEY]
+   }

--- a/README.md
+++ b/README.md
@@ -118,21 +118,24 @@ Adapters and node toml files to implement the API are available on github
 
 Truflation data is fully available on Base, with cross-chain access supported via Chainlink CCIP.
 
-**Note:** As of December 2025, specific Chainlink "Any API" oracle/job IDs for Truflation indexes directly on Base mainnet are not yet publicly listed in this repo. Modern integrations often use Chainlink Data Streams or API calls. Check these resources for the latest:
+**Note:** As of December 2025, the legacy Chainlink "Any API" style (with fixed job IDs) used in this quickstart is primarily for testnets. On Base mainnet, Truflation recommends modern **Chainlink Data Streams** or custom streams via the Marketplace.
 
-- Truflation Marketplace (data stream IDs): https://marketplace.truflation.com/
-- Chainlink Data Streams docs: https://docs.chain.link/data-streams
-- Chainlink CCIP (cross-chain): https://docs.chain.link/ccip
+For the latest Base-compatible configurations:
+- [Truflation Marketplace](https://marketplace.truflation.com/) – Select your data stream, chain (Base), and copy the oracle address/job ID if needed.
+- [Chainlink Data Streams docs](https://docs.chain.link/data-streams)
+- [Chainlink CCIP docs](https://docs.chain.link/ccip) (for cross-chain)
 
 ### Quick Steps:
 1. Use Remix or Hardhat with Base network config.
-2. In `TruflationTester.sol`, update with the latest parameters from the resources above.
-3. Fund your contract with LINK on Base (use faucets for testnet or bridges for mainnet).
+2. Open `TruflationTester.sol` and update the oracle parameters:
+   - Go to the Marketplace link above, select your index and Base chain.
+   - Copy the provided **oracle address** and **job ID**.
+   - Paste them into the contract (replace the placeholders in the `requestYoYInflation` function or constructor).
+3. Fund your contract with LINK on Base (use faucets for testnet like Base Sepolia, or bridges for mainnet).
 4. Example Hardhat network config (add to your `hardhat.config.js`):
    ```js
    base: {
      url: "https://mainnet.base.org",
      accounts: [process.env.PRIVATE_KEY],
      chainId: 8453  // Use 84532 for Base Sepolia testnet
-   }
    }

--- a/README.md
+++ b/README.md
@@ -116,15 +116,23 @@ Adapters and node toml files to implement the API are available on github
 * [Using solt to get a contract on etherscan](https://blog.jubb.xyz/post/solt-release/)
 ## Deploying on Base (Coinbase's Layer 2)
 
-Truflation data is fully available on Base via Chainlink CCIP for cross-chain queries.
+Truflation data is fully available on Base, with cross-chain access supported via Chainlink CCIP.
+
+**Note:** As of December 2025, specific Chainlink "Any API" oracle/job IDs for Truflation indexes directly on Base mainnet are not yet publicly listed in this repo. Modern integrations often use Chainlink Data Streams or API calls. Check these resources for the latest:
+
+- Truflation Marketplace (data stream IDs): https://marketplace.truflation.com/
+- Chainlink Data Streams docs: https://docs.chain.link/data-streams
+- Chainlink CCIP (cross-chain): https://docs.chain.link/ccip
 
 ### Quick Steps:
 1. Use Remix or Hardhat with Base network config.
-2. In `TruflationTester.sol`, ensure you're using the latest Chainlink oracle addresses for Base.
-3. Fund your contract with LINK on Base (get from faucets or bridges).
-4. Example network config (add to your hardhat.config.js):
+2. In `TruflationTester.sol`, update with the latest parameters from the resources above.
+3. Fund your contract with LINK on Base (use faucets for testnet or bridges for mainnet).
+4. Example Hardhat network config (add to your `hardhat.config.js`):
    ```js
    base: {
      url: "https://mainnet.base.org",
-     accounts: [process.env.PRIVATE_KEY]
+     accounts: [process.env.PRIVATE_KEY],
+     chainId: 8453  // Use 84532 for Base Sepolia testnet
+   }
    }

--- a/README.md
+++ b/README.md
@@ -118,23 +118,27 @@ Adapters and node toml files to implement the API are available on github
 
 Truflation data is fully available on Base, with cross-chain access supported via Chainlink CCIP.
 
-**Note:** As of December 2025, the legacy Chainlink "Any API" style (with fixed job IDs) used in this quickstart is primarily for testnets. On Base mainnet, Truflation recommends modern **Chainlink Data Streams** or custom streams via the Marketplace.
+**Note:** As of December 2025, the legacy Chainlink "Any API" style (with fixed job IDs) in this quickstart is primarily for testnets. On Base mainnet, Truflation recommends modern **Chainlink Data Streams** or custom streams via the Marketplace for low-latency, production use.
 
-For the latest Base-compatible configurations:
-- [Truflation Marketplace](https://marketplace.truflation.com/) – Select your data stream, chain (Base), and copy the oracle address/job ID if needed.
+For the latest configurations:
+- [Truflation Marketplace](https://marketplace.truflation.com/) – Select your data stream and Base chain to get custom oracle/job details if needed.
 - [Chainlink Data Streams docs](https://docs.chain.link/data-streams)
-- [Chainlink CCIP docs](https://docs.chain.link/ccip) (for cross-chain)
+- [Chainlink CCIP docs](https://docs.chain.link/ccip)
 
-### Quick Steps:
-1. Use Remix or Hardhat with Base network config.
-2. Open `TruflationTester.sol` and update the oracle parameters:
-   - Go to the Marketplace link above, select your index and Base chain.
-   - Copy the provided **oracle address** and **job ID**.
-   - Paste them into the contract (typically in the constructor parameters or in the Chainlink request setup function, replacing any placeholders).
-3. Fund your contract with LINK on Base:
-   - For testnet (Base Sepolia): Use the [Chainlink Faucet](https://faucets.chain.link/base-sepolia) (provides test LINK and ETH).
-   - For mainnet: Bridge LINK from Ethereum or other chains using a trusted bridge like [Base Official Bridge](https://bridge.base.org/) or third-party options.
-4. Example Hardhat network config (add to your `hardhat.config.js`):
+### Quick Steps for TruflationTester.sol on Base:
+1. Use Remix or Hardhat with Base network config (example below).
+2. When deploying the contract:
+   - Pass parameters to the **constructor** (address oracleId_, string jobId_, uint256 fee_, address token_).
+   - Get oracle address and job ID from the Truflation Marketplace (select index + Base chain).
+   - Use fee: 0.1 - 0.5 LINK (in wei, e.g., 100000000000000000 for 0.1 LINK – common for requests).
+   - LINK token address:
+     - Mainnet: 0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196
+     - Testnet (Base Sepolia): 0xE4aB69C077896252FAFBD49EFD26B5D171A32410
+3. Fund your deployed contract with LINK:
+   - Testnet (Base Sepolia): Use the [Chainlink Faucet](https://faucets.chain.link/base-sepolia) (provides test LINK + ETH).
+   - Mainnet: Bridge LINK using the [official Base Bridge](https://bridge.base.org/deposit) or other trusted bridges.
+4. Call `requestYoyInflation()` on the deployed contract to fetch data.
+5. Example Hardhat network config (add to your `hardhat.config.js`):
    ```js
    base: {
      url: "https://mainnet.base.org",

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For the latest configurations:
 1. Use Remix or Hardhat with Base network config (example below).
 2. When deploying the contract (constructor: address oracleId_, string jobId_, uint256 fee_, address token_):
    - Get oracle address and job ID from the Truflation Marketplace (select index + Base chain).
-   - Fee: 0.1 - 0.5 LINK (in wei, e.g., 0.1 LINK = 100000000000000000).
+   - Fee: 0.1 – 0.5 LINK (in wei, e.g., 0.1 LINK = 100000000000000000).
    - LINK token address (official Chainlink):
      - Mainnet: 0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196
      - Testnet (Base Sepolia): 0xE4aB69C077896252FAFBD49EFD26B5D171A32410


### PR DESCRIPTION
This PR adds a dedicated section for deploying and using Truflation oracles on Base – Coinbase's Layer 2 where Truflation is natively supported and funded via the Base Ecosystem Fund.

Changes:
- New "Deploying on Base" section in README.md
- Hardhat/Remix config examples
- Notes on Chainlink CCIP and LINK funding on Base

Benefits:
- Lowers barrier for Base ecosystem developers
- Supports onchain farming and RWA projects using real-time economic data
- Aligns with Truflation's strategic Base integration and Brian Armstrong's praise

Happy to adjust or add more examples! 🚀 @truflation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README section on deploying to Base (Coinbase Layer 2) and using Chainlink CCIP for cross‑chain access.
  * Recommends Chainlink Data Streams or marketplace-based streams over legacy Any API; notes limited public Any API IDs on Base mainnet.
  * Adds quick setup steps: selecting streams, updating oracle/job settings, funding with LINK on Base (testnet/mainnet guidance), and sample network config.
  * No functional code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->